### PR TITLE
Consume configuration env variables in container run

### DIFF
--- a/.build/config.js
+++ b/.build/config.js
@@ -1,0 +1,5 @@
+const configVars = ['API_ENTRYPOINTS', 'HTML5_HISTORY', 'BASE_URL', 'APP_PATH']
+
+console.log(`window.env = {
+  ${configVars.map(varName => `${varName}: '${process.env[varName] || ''}'`).join(',\n  ')}
+}`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.12.0"></a>
+# [0.12.0](https://github.com/hypermedia-app/generic-hypermedia-app/compare/v0.11.0...v0.12.0) (2019-11-15)
+
+
+### Bug Fixes
+
+* change logo ([bdd8f24](https://github.com/hypermedia-app/generic-hypermedia-app/commit/bdd8f24))
+* parametrize the shell ([c797104](https://github.com/hypermedia-app/generic-hypermedia-app/commit/c797104))
+* typescript errors ([1aaba42](https://github.com/hypermedia-app/generic-hypermedia-app/commit/1aaba42))
+
+
+### Features
+
+* passing headers to operation ([8dd33e2](https://github.com/hypermedia-app/generic-hypermedia-app/commit/8dd33e2))
+* populate entrypoint dropdown from environment variables ([d5ada4e](https://github.com/hypermedia-app/generic-hypermedia-app/commit/d5ada4e)), closes [#42](https://github.com/hypermedia-app/generic-hypermedia-app/issues/42)
+* prepare Dockerfile ([d8cc1a1](https://github.com/hypermedia-app/generic-hypermedia-app/commit/d8cc1a1)), closes [#41](https://github.com/hypermedia-app/generic-hypermedia-app/issues/41)
+* shift+click to open a link in new tab (window) ([1c26b35](https://github.com/hypermedia-app/generic-hypermedia-app/commit/1c26b35))
+* show hints when hovering one properties, links etc ([b6e0b06](https://github.com/hypermedia-app/generic-hypermedia-app/commit/b6e0b06))
+
+
+
 <a name="0.11.0"></a>
 # [0.11.0](https://github.com/hypermedia-app/generic-hypermedia-app/compare/v0.10.2...v0.11.0) (2019-08-14)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN npm ci
 
 ADD . .
 ENV NODE_ENV=production
+ENV RUNTIME_CONFIG=true
 RUN npm run build
 
 FROM node:lts-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,9 @@ RUN npm run build
 
 FROM node:lts-alpine
 
-RUN npm install -g local-web-server
+RUN npm install -g local-web-server dotenv-cli
 COPY --from=builder /app/dist ./
-
-USER nobody:nobody
+COPY --from=builder /app/.build/ ./.build
 
 EXPOSE 8000
-CMD [ "ws", "-s", "index.html" ]
+CMD [ "sh", "-c", "dotenv -e .env.defaults node ./.build/config.js > ./config.js; ws -s index.html" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generic-hypermedia-app",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generic-hypermedia-app",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "main": "src/index.js",
   "license": "MIT",
   "author": "Tomasz Pluskiewicz <awesome@hypermedia.app>",

--- a/src/components/hypermedia-app-shell/index.ts
+++ b/src/components/hypermedia-app-shell/index.ts
@@ -3,11 +3,14 @@ import { HydrofoilPaperShell } from '@hydrofoil/hydrofoil-paper-shell/hydrofoil-
 import '@hydrofoil/hydrofoil-paper-shell/hydrofoil-resource-accordion'
 import '@polymer/paper-spinner/paper-spinner'
 import { Hydra } from 'alcaeus'
-import { ReflectedInHash } from 'ld-navigation'
+import { ReflectedInHash, ReflectedInHistory } from 'ld-navigation'
 import { IHydraResponse } from 'alcaeus/types/HydraResponse'
 import { HydraInvokeOperationEvent } from '../../forms'
+import env from '../../env'
 
-export default class HypermediaAppShell extends ReflectedInHash(AlcaeusLoader(HydrofoilPaperShell)) {
+const Reflector = env.HTML5_HISTORY ? ReflectedInHistory : ReflectedInHash
+
+export default class HypermediaAppShell extends Reflector(AlcaeusLoader(HydrofoilPaperShell)) {
   public constructor() {
     super()
     this.clientBasePath = ''

--- a/src/components/hypermedia-app/index.ts
+++ b/src/components/hypermedia-app/index.ts
@@ -10,12 +10,7 @@ import fireNavigation from 'ld-navigation/fireNavigation'
 import ApiDocumentationViewer from '../api-documentation/viewer'
 import '../hypermedia-app-shell'
 import { version } from '../../../package.json'
-
-const apis = Object.entries(JSON.parse(process.env.API_ENTRYPOINTS))
-  .map(entry => ({
-    url: entry[0],
-    title: entry[1],
-  }))
+import env from '../../env'
 
 @customElement('hypermedia-app')
 export default class HypermediaApp extends PolymerElement {
@@ -38,19 +33,21 @@ export default class HypermediaApp extends PolymerElement {
   }
 
   public get apis() {
-    return apis
+    const configEntrypoints = env.API_ENTRYPOINTS ? JSON.parse(env.API_ENTRYPOINTS) : {}
+
+    return Object.entries(configEntrypoints)
+      .map(entry => ({
+        url: entry[0],
+        title: entry[1],
+      }))
   }
 
   public get baseUrl() {
-    return process.env.BASE_URL
+    return env.BASE_URL
   }
 
   public get appPath() {
-    return process.env.APP_PATH
-  }
-
-  public get html5History() {
-    return !!process.env.HTML5_HISTORY
+    return env.APP_PATH
   }
 
   public static get template() {
@@ -76,7 +73,6 @@ export default class HypermediaApp extends PolymerElement {
 
       <hypermedia-app-shell
         url="{{url}}"
-        use-hash-urls$="[[!html5History]]"
         base-url="[[baseUrl]]"
         client-base-path="[[appPath]]"
         on-model-changed="enableDoc"

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,10 @@
+const env = {
+  API_ENTRYPOINTS: process.env.API_ENTRYPOINTS,
+  BASE_URL: process.env.BASE_URL,
+  HTML5_HISTORY: process.env.HTML5_HISTORY,
+  APP_PATH: process.env.APP_PATH,
+}
+
+const globalEnv = (window as any).env as typeof env
+
+export default globalEnv || env

--- a/src/index.html
+++ b/src/index.html
@@ -61,6 +61,7 @@
     </style>
   </custom-style>
 
+  <script src="config.js"></script>
   <script>
     (function() {
       if (!('serviceWorker' in navigator)) {

--- a/src/index.html
+++ b/src/index.html
@@ -61,7 +61,9 @@
     </style>
   </custom-style>
 
+  <% if (htmlWebpackPlugin.options.runtimeConfig) { %>
   <script src="config.js"></script>
+  <% } %>
   <script>
     (function() {
       if (!('serviceWorker' in navigator)) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,6 +101,7 @@ const renderHtmlPlugins = () => [
     paths: {
       webcomponents: './vendor/webcomponents-loader.js',
     },
+    runtimeConfig: !!process.env.RUNTIME_CONFIG,
   }),
   new HtmlWebpackExcludeAssetsPlugin(),
   new ScriptExtHtmlWebpackPlugin({


### PR DESCRIPTION
@thewilkybarkid I did similarly to what you shared. When the container starts, the configuration env  variables are injected into a `config.js` file which simply populates an object on `window`

During development `.env` is used as before.